### PR TITLE
Structure 'action' template as a ConfirmAction.

### DIFF
--- a/templates/action.html
+++ b/templates/action.html
@@ -7,13 +7,14 @@
 <link href="styles.css" media="all" rel="stylesheet" type="text/css" />
 </head>
 
-<body>
+<body itemscope itemtype="http://schema.org/EmailMessage">
 
 <table class="body-wrap">
 	<tr>
 		<td></td>
 		<td class="container" width="600">
-			<div class="content">
+			<div class="content" itemprop="action" itemscope itemtype="http://schema.org/ConfirmAction">
+				<meta itemprop="name" content="Confirm Email"/>
 				<table class="main" width="100%" cellpadding="0" cellspacing="0">
 					<tr>
 						<td class="content-wrap">
@@ -29,8 +30,8 @@
 									</td>
 								</tr>
 								<tr>
-									<td class="content-block">
-										<a href="http://www.mailgun.com" class="btn-primary">Confirm email address</a>
+									<td class="content-block" itemprop="handler" itemscope itemtype="http://schema.org/HttpActionHandler">
+										<a href="http://www.mailgun.com" class="btn-primary" itemprop="url">Confirm email address</a>
 									</td>
 								</tr>
 								<tr>


### PR DESCRIPTION
Markup the action transactional template to make it actionable. The email is now:

- an `EmailMessage` (http://schema.org/EmailMessage)
- containing a `HttpActionHandler` (https://developers.google.com/schemas/reference/types/HttpActionHandler)
- with a `ConfirmAction` (http://schema.org/ConfirmAction)

This gives the template direct actionability in the
Gmail Actions in the Inbox platform (https://developers.google.com/gmail/actions/), exposing
`ConfirmAction` (https://developers.google.com/gmail/actions/reference/one-click-action#confirm_action).