### PR TITLE
Fixing two iOS display issues

### DIFF
--- a/templates/styles.css
+++ b/templates/styles.css
@@ -232,6 +232,10 @@ a {
     RESPONSIVE AND MOBILE FRIENDLY STYLES
 ------------------------------------- */
 @media only screen and (max-width: 640px) {
+  body {
+    /* Apple iOS Mail app defaults to 20px which makes our template too skinny */
+    padding: 10px;
+  }
   h1, h2, h3, h4 {
     font-weight: 600 !important;
     margin: 20px 0 5px !important;

--- a/templates/styles.css
+++ b/templates/styles.css
@@ -237,7 +237,8 @@ a {
     padding: 10px;
   }
   h1, h2, h3, h4 {
-    font-weight: 600 !important;
+    /* Use 800 or 400; 600 looks wonky on iOS 8 */
+    font-weight: 800 !important;
     margin: 20px 0 5px !important;
   }
 


### PR DESCRIPTION
1) Mail app on iOS 8 the default body padding is 20px. This makes the template rather skinny. Most modern email templates have a smaller left and right body padding of 10px.

20px padding: http://cl.ly/image/0x2b3e2P1i2b
10px padding: http://cl.ly/image/1p2h1b2Z0m1E

2) Mail app on iOS 8, Helvetica's 600 weight font looks wonky. The letter-spacing and font-weight looks off. 

600 weight: http://cl.ly/image/0x2b3e2P1i2b
800 weight: http://cl.ly/image/1p2h1b2Z0m1E