### PR TITLE
Remove duplicate CSS color for .footer a

### DIFF
--- a/templates/styles.css
+++ b/templates/styles.css
@@ -83,9 +83,6 @@ body {
   color: #999;
   padding: 20px;
 }
-.footer a {
-  color: #999;
-}
 .footer p, .footer a, .footer unsubscribe, .footer td {
   color: #999;
   font-size: 12px;


### PR DESCRIPTION
As a result of the changes in 1ca759d, the color for ".footer a" ended
up being specified twice - it should be safe to remove one of these.