### PR TITLE
Remove unused CSS selector: .footer unsubscribe

### DIFF
--- a/templates/styles.css
+++ b/templates/styles.css
@@ -83,7 +83,7 @@ body {
   color: #999;
   padding: 20px;
 }
-.footer p, .footer a, .footer unsubscribe, .footer td {
+.footer p, .footer a, .footer td {
   color: #999;
   font-size: 12px;
 }


### PR DESCRIPTION
This CSS selector seems to refer to a bogus HTML element
("unsubscribe").  Probably it was intended to be ".footer .unsubscribe"
(with a dot), but there doesn't seem to be any "unsubcribe" class used
in the HTML files, so it should be safe to just delete the selector
entirely.